### PR TITLE
grafana provision config as files

### DIFF
--- a/dashboards/controller_dashboard.json
+++ b/dashboards/controller_dashboard.json
@@ -224,8 +224,9 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "New dashboard",
+  "title": "SOSReport AAP Controller Postmortem",
   "uid": "dc8b7069-52f3-4d11-8c16-6757399efb49",
   "version": 4,
   "weekStart": ""
 }
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -43,28 +43,15 @@ services:
       - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
-    entrypoint:
-      - sh
-      - -euc
-      - |
-        mkdir -p /etc/grafana/provisioning/datasources
-        cat <<EOF > /etc/grafana/provisioning/datasources/ds.yaml
-        apiVersion: 1
-        datasources:
-        - name: Loki
-          type: loki
-          access: proxy 
-          orgId: 1
-          url: http://loki:3100
-          timeout: 300
-          basicAuth: false
-          isDefault: true
-          version: 1
-          editable: false
-        EOF
-        /run.sh
+      - GF_LOG_MODE=console
+      #- GF_LOG_LEVEL=debug
+    #privileged: true
+    entrypoint: /run.sh
     image: grafana/grafana:latest
     ports:
       - "3001:3000"
+    volumes:
+      - ${PWD}/docker/grafana/etc/grafana/provisioning/:/etc/grafana/provisioning/
+      - ${PWD}/dashboards:/opt/grafana/dashboards
     networks:
       - loki

--- a/docker/grafana/etc/grafana/provisioning/dashboards/dashboards.yml
+++ b/docker/grafana/etc/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+providers:
+  - name: dashboards
+    orgId: 1
+    type: file
+    updateIntervalSeconds: 10
+    allowUiUpdates: false
+    options:
+      path: /opt/grafana/dashboards/
+      foldersFromFilesStructure: true

--- a/docker/grafana/etc/grafana/provisioning/datasources/loki.yaml
+++ b/docker/grafana/etc/grafana/provisioning/datasources/loki.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    orgId: 1
+    url: http://loki:3100
+    timeout: 300
+    basicAuth: false
+    isDefault: true
+    version: 1
+    editable: false


### PR DESCRIPTION
* Move grafana provisioning of datasource and dashboard to files from docker-compose.yml
* Auto provision dashboard